### PR TITLE
Change composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-    "name": "datafeedwatch/connector",
+    "name": "datafeedwatch/dfwconnector-magento2",
     "description": "N/A",
     "require": {
         "php": "7.*||~8.1.0||~8.2.0"
     },
     "type": "magento2-module",
-    "version": "3.2.2",
+    "version": "3.2.3",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
This is part of the migration to a new module name (`connector` -> `dfwconnector-magento2`). For now the nameespace will remain as it is (`DataFeedWatch\\Connector\\`).

Ticket: WW-9077
Url: https://cartdotcom.atlassian.net/browse/WW-9077