### PR TITLE
Add `min_sale_qty` field to qty and stock data

### DIFF
--- a/Api/Data/QtyAndStockInterface.php
+++ b/Api/Data/QtyAndStockInterface.php
@@ -33,6 +33,11 @@ interface QtyAndStockInterface extends ExtensibleDataInterface
     public function getIsInStock();
 
     /**
+     * @return float|null
+     */
+    public function getMinSaleQty();
+
+    /**
      * @param float|null $qty
      * @return $this
      */
@@ -49,6 +54,12 @@ interface QtyAndStockInterface extends ExtensibleDataInterface
      * @return $this
      */
     public function setIsInStock($isInStock);
+
+    /**
+     * @param float|null $minSaleQty
+     * @return $this
+     */
+    public function setMinSaleQty($minSaleQty);
 
     /**
      * @return \DataFeedWatch\Connector\Api\Data\QtyAndStockExtensionInterface|null

--- a/Model/QtyAndStock.php
+++ b/Model/QtyAndStock.php
@@ -21,6 +21,7 @@ class QtyAndStock extends AbstractExtensibleObject implements QtyAndStockInterfa
     const KEY_QTY = 'qty';
     const KEY_MANAGE_STOCK = 'manage_stock';
     const KEY_IS_IN_STOCK = 'is_in_stock';
+    const MIN_SALE_QTY = 'min_sale_qty';
 
     public function getQty()
     {
@@ -35,6 +36,11 @@ class QtyAndStock extends AbstractExtensibleObject implements QtyAndStockInterfa
     public function getIsInStock()
     {
         return $this->_get(self::KEY_IS_IN_STOCK);
+    }
+
+    public function getMinSaleQty()
+    {
+        return $this->_get(self::MIN_SALE_QTY);
     }
 
     /**

--- a/Model/QtyAndStock.php
+++ b/Model/QtyAndStock.php
@@ -23,6 +23,10 @@ class QtyAndStock extends AbstractExtensibleObject implements QtyAndStockInterfa
     const KEY_IS_IN_STOCK = 'is_in_stock';
     const MIN_SALE_QTY = 'min_sale_qty';
 
+    public function getMinSaleQty() {
+        return $this->_get(self::MIN_SALE_QTY);
+    }
+
     public function getQty()
     {
         return $this->_get(self::KEY_QTY);
@@ -36,11 +40,6 @@ class QtyAndStock extends AbstractExtensibleObject implements QtyAndStockInterfa
     public function getIsInStock()
     {
         return $this->_get(self::KEY_IS_IN_STOCK);
-    }
-
-    public function getMinSaleQty()
-    {
-        return $this->_get(self::MIN_SALE_QTY);
     }
 
     /**
@@ -58,6 +57,16 @@ class QtyAndStock extends AbstractExtensibleObject implements QtyAndStockInterfa
     public function setExtensionAttributes(\DataFeedWatch\Connector\Api\Data\QtyAndStockExtensionInterface $extensionAttributes)
     {
         return $this->_setExtensionAttributes($extensionAttributes);
+    }
+
+    /**
+     * @param float|null $minSaleQty
+     * @return $this
+     */
+    public function setMinSaleQty($minSaleQty)
+    {
+        $this->setData(self::MIN_SALE_QTY, $minSaleQty);
+        return $this;
     }
 
     /**

--- a/Plugin/QtyAndStock.php
+++ b/Plugin/QtyAndStock.php
@@ -104,6 +104,7 @@ class QtyAndStock extends Quantity
                     'qty' => $this->getExtensionData($product),
                     'manage_stock' => (bool)$this->getManageStock($product),
                     'is_in_stock' => (bool)$this->getStockStatus($product),
+                    'min_sale_qty' => $this->getMinSaleQty($product) ?? 1,
                 ];
                 $this->dataObjectHelper->populateWithArray($qtyAndStock, $qtyAndStockData, QtyAndStockInterface::class);
                 $extensionAttributes->setQtyAndStock($qtyAndStock);

--- a/Plugin/QtyAndStock.php
+++ b/Plugin/QtyAndStock.php
@@ -185,7 +185,7 @@ class QtyAndStock extends Quantity
     protected function getMinSaleQty(Product $product): ?float
     {
         $connection = $this->resourceConnection->getConnection();
-        $tableName = $this->resourceConnection->getTableName(self::STOCK_TABLE);
+        $tableName = $this->resourceConnection->getTableName(self::LEGACY_STOCK_TABLE);
 
         $query = sprintf(
             "SELECT `min_sale_qty`, `use_config_min_sale_qty` FROM `%s` WHERE `product_id` = :product_id%s",
@@ -199,7 +199,7 @@ class QtyAndStock extends Quantity
 
         $minSaleQty = $connection->fetchRow($query, $bind);
 
-        if (!$minSaleQty['use_config_min_qty']) {
+        if (!$minSaleQty['use_config_min_sale_qty']) {
             return $minSaleQty['min_sale_qty'];
         }
 


### PR DESCRIPTION
As per request, the `min_sale_qty` was added to the `qty_and_stock` information returned from the API.

Ticket: WW-10619
Url: https://cartdotcom.atlassian.net/browse/WW-10619