### PR TITLE
WWATCH-17 - Magento_Staging compatibility fix

### DIFF
--- a/Plugin/ParentIds.php
+++ b/Plugin/ParentIds.php
@@ -77,7 +77,7 @@ class ParentIds extends ExtensionAttributeAbstract
             return $connection->fetchCol($query);
         } else {
             $query = $connection->select()
-                ->from(['r' => $tableName], 'parent_id')
+                ->from(['r' => $tableName], '')
                 ->join(
                     ['e' => $entityTable],
                     'r.parent_id = e.row_id',


### PR DESCRIPTION
The join alias having the same name as table column `parent_id` caused wrong column to be selected. Now correct column `e.entity_id` is selected as `parent_id`.