### PR TITLE
Return the correct URL in case redirects exist

### DIFF
--- a/Plugin/ProductUrl.php
+++ b/Plugin/ProductUrl.php
@@ -63,7 +63,7 @@ class ProductUrl extends ExtensionAttributeAbstract
         $tableName = $this->resourceConnection->getTableName(self::URL_REWRITE_TABLE);
 
         $query = sprintf(
-            "SELECT `request_path` FROM `%s` WHERE `entity_id` = '%s' AND `store_id` = %s AND `entity_type` = 'product' AND `metadata` IS NULL",
+            "SELECT `request_path` FROM `%s` WHERE `entity_id` = '%s' AND `store_id` = %s AND `entity_type` = 'product' AND `metadata` IS NULL AND `redirect_type` = 0",
             $tableName,
             $product->getId(),
             $product->getStoreId()


### PR DESCRIPTION
The plugin selects the wrong URL from the `url_rewrite` table, in case there is more than one URL for a specific product.
This is a common scenario when renaming products, as that causes Magento to create a redirect.

```
MySQL [magento-shop]> SELECT `request_path` FROM `url_rewrite` WHERE `entity_id` = '1234' AND `entity_type` = 'product' AND `metadata` IS NULL AND store_id = 8;
+--------------+
| request_path |
+--------------+
| 71234.html   |
| 1234.html    |
| 1234.aspx    |
+--------------+
3 rows in set (0.001 sec)

MySQL [magento-shop]> SELECT * FROM `url_rewrite` WHERE `entity_id` = '1234' AND `entity_type` = 'product' AND `metadata` IS NULL AND store_id = 8;
+----------------+-------------+-----------+--------------+-------------------------------+---------------+----------+--------------------+------------------+----------+
| url_rewrite_id | entity_type | entity_id | request_path | target_path                   | redirect_type | store_id | description        | is_autogenerated | metadata |
+----------------+-------------+-----------+--------------+-------------------------------+---------------+----------+--------------------+------------------+----------+
|         330758 | product     |     1234  | 71234.html   | 1234.html                     |           301 |        8 | NULL               |                1 | NULL     |
|        2411382 | product     |     1234  | 1234.html    | catalog/product/view/id/1234  |             0 |        8 | NULL               |                1 | NULL     |
|        2853322 | product     |     1234  | 1234.aspx    | 1234.html                     |           301 |        8 | migration redirect |                0 | NULL     |
+----------------+-------------+-----------+--------------+-------------------------------+---------------+----------+--------------------+------------------+----------+
3 rows in set (0.002 sec)

MySQL [magento-shop]>
```